### PR TITLE
Redirect if there is no trailing /

### DIFF
--- a/cicd/app/rasd_static.yaml
+++ b/cicd/app/rasd_static.yaml
@@ -172,8 +172,18 @@ Resources:
                             request.uri += 'index.html';
                         }
                         // Check whether the URI is missing a file extension.
+                        // Redirect in this case otherwise relative links will
+                        // be broken
                         else if (!uri.includes('.')) {
                             request.uri += '/index.html';
+                            var response = {
+                                  statusCode: 301,
+                                  statusDescription: 'Moved Permanently',
+                                  headers:
+                                    { "location": { "value": request.uri } }
+                                }
+
+                            return response;
                         }
 
                         return request;


### PR DESCRIPTION
Redirect when there is no trailing / in a request URI rather than rewrite. This is to prevent broken relative links