### PR TITLE
default index.html doc for directories

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -291,7 +291,7 @@
             <img class="logo"
             src="images/logos/SAgov-logo.jpg"
             alt="SA Government logo"
-            width="70%"
+            width="90%"
             height="auto"
             /></a>
         </div>


### PR DESCRIPTION
This change configures index.html as a default document if a request is made to a directory. Works with or without a trailing slash