### PR TITLE
Feature/update common infra

### DIFF
--- a/cicd/pipeline/gen_template_config.py
+++ b/cicd/pipeline/gen_template_config.py
@@ -25,18 +25,18 @@ template = template_env.get_template(args.template)
 template_vals = {
     "artifacts_bucket"            : os.environ['ARTIFACTS_BUCKET'],
     "branch"                      : os.environ['SRC_BRANCH'],
-    "build"                       : os.environ['CODEBUILD_BUILD_NUMBER'],
     "bucket_name"                 : os.environ['SOURCE_BUCKET'],
     "bucket_path"                 : os.environ['BUCKET_PATH'],
-    "commit_id"                   : os.environ['COMMIT_ID'],
+    "build"                       : os.environ['CODEBUILD_BUILD_NUMBER'],
     "clean_branch"                : os.environ['CLEAN_BRANCH'],
+    "commit_id"                   : os.environ['COMMIT_ID'],
     "environment"                 : os.environ['ENVIRONMENT'],
     "hosted_zone"                 : os.environ['HOSTED_ZONE'],
     "hosted_zone_id"              : os.environ['HOSTED_ZONE_ID'],
     "product_component"           : os.environ['PRODUCT_COMPONENT'],
     "product_name"                : os.environ['PRODUCT_NAME'],
-    "sub_domain"                  : os.environ['SUB_DOMAIN'],
     "ssl_certificate"             : os.environ['SSL_CERTIFICATE']
+    "sub_domain"                  : os.environ['SUB_DOMAIN'],
 }
 
 # do the substitution

--- a/cicd/pipeline/gen_template_config.py
+++ b/cicd/pipeline/gen_template_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 ###
-# Genarate the template configuration, used to pass in the parameters to the
+# Generate the template configuration, used to pass in the parameters to the
 # CloudFormation template and add aws resource tags
 # Usage: gen_template_config.py --template [/path/to/template_config.json]
 
@@ -35,8 +35,8 @@ template_vals = {
     "hosted_zone_id"              : os.environ['HOSTED_ZONE_ID'],
     "product_component"           : os.environ['PRODUCT_COMPONENT'],
     "product_name"                : os.environ['PRODUCT_NAME'],
-    "ssl_certificate"             : os.environ['SSL_CERTIFICATE']
-    "sub_domain"                  : os.environ['SUB_DOMAIN'],
+    "ssl_certificate"             : os.environ['SSL_CERTIFICATE'],
+    "sub_domain"                  : os.environ['SUB_DOMAIN']
 }
 
 # do the substitution

--- a/cicd/pipeline/rasd_static_template_config.j2
+++ b/cicd/pipeline/rasd_static_template_config.j2
@@ -5,8 +5,8 @@
     "pCleanBranch"    : "{{ clean_branch }}",
     "pEnvironment"    : "{{ environment }}",
     "pHostedZone"     : "{{ hosted_zone }}",
-    "pSslCertificate" : "{{ ssl_certificate }}"
-    "pSubDomain"      : "{{ sub_domain }}",
+    "pSslCertificate" : "{{ ssl_certificate }}",
+    "pSubDomain"      : "{{ sub_domain }}"
   },
   "Tags" : {
     "product"     : "{{ product_name }}",

--- a/cicd/pipeline/rasd_static_template_config.j2
+++ b/cicd/pipeline/rasd_static_template_config.j2
@@ -1,12 +1,12 @@
 {
   "Parameters" : {
-    "pEnvironment"    : "{{ environment }}",
     "pBucketName"     : "{{ bucket_name }}",
     "pBucketPath"     : "{{ bucket_path }}",
     "pCleanBranch"    : "{{ clean_branch }}",
+    "pEnvironment"    : "{{ environment }}",
     "pHostedZone"     : "{{ hosted_zone }}",
-    "pSubDomain"      : "{{ sub_domain }}",
     "pSslCertificate" : "{{ ssl_certificate }}"
+    "pSubDomain"      : "{{ sub_domain }}",
   },
   "Tags" : {
     "product"     : "{{ product_name }}",

--- a/config.ini
+++ b/config.ini
@@ -18,10 +18,10 @@ MAX_AGE = 0
 PIPELINE_STACK_NAME = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-pipeline-${CLEAN_BRANCH} 
 APP_STACK_NAME = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-${CLEAN_BRANCH} 
 CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:731167336288:connection/5191779b-dbc8-4a90-a5f0-e15c5da13dfa
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-testing-731167336288
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::731167336288:role/cloud-formation-service-role-testing
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::731167336288:role/service-role/code-build-service-role-testing
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::731167336288:role/code-pipeline-service-role-testing
+ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-731167-ap-southeast-2-production
+CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::731167336288:role/cloud-formation-service-role-production
+CODEBUILD_SERVICE_ROLE = arn:aws:iam::731167336288:role/service-role/code-build-service-role-production
+CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::731167336288:role/code-pipeline-service-role-production
 # bucket
 SOURCE_BUCKET = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-${CLEAN_BRANCH}
 MAX_AGE = 0
@@ -38,10 +38,10 @@ DOCUMENT_ROOT = index.html
 PIPELINE_STACK_NAME = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-pipeline-${ENVIRONMENT} 
 APP_STACK_NAME = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-${ENVIRONMENT} 
 CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:731167336288:connection/5191779b-dbc8-4a90-a5f0-e15c5da13dfa
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-testing-731167336288
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::731167336288:role/cloud-formation-service-role-testing
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::731167336288:role/service-role/code-build-service-role-testing
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::731167336288:role/code-pipeline-service-role-testing
+ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-731167-ap-southeast-2-production
+CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::731167336288:role/cloud-formation-service-role-production
+CODEBUILD_SERVICE_ROLE = arn:aws:iam::731167336288:role/service-role/code-build-service-role-production
+CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::731167336288:role/code-pipeline-service-role-production
 # bucket
 SOURCE_BUCKET = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-${ENVIRONMENT}
 MAX_AGE = 0
@@ -55,10 +55,10 @@ DOCUMENT_ROOT = index.html
 [staging]
 # code pipeline
 CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:736913556139:connection/a13c92b1-cb4e-437e-ad63-d6035c67fe77
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-staging
-CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::736913556139:role/cloud-formation-service-role-staging
-CODEBUILD_SERVICE_ROLE = arn:aws:iam::736913556139:role/service-role/code-build-service-role-staging
-CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::736913556139:role/code-pipeline-service-role-staging
+ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-736913-ap-southeast-2-production
+CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::736913556139:role/cloud-formation-service-role-production
+CODEBUILD_SERVICE_ROLE = arn:aws:iam::736913556139:role/service-role/code-build-service-role-production
+CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::736913556139:role/code-pipeline-service-role-production
 # bucket
 SOURCE_BUCKET = ala-${PRODUCT_NAME}-${PRODUCT_COMPONENT}-${ENVIRONMENT}
 MAX_AGE = 30
@@ -72,7 +72,7 @@ DOCUMENT_ROOT = index.html
 [production]
 # code pipeline
 CODESTAR_CONNECTION = arn:aws:codestar-connections:ap-southeast-2:736913556139:connection/a13c92b1-cb4e-437e-ad63-d6035c67fe77
-ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-production
+ARTIFACTS_BUCKET = ala-code-pipeline-artifacts-736913-ap-southeast-2-production
 CLOUDFORMATION_SERVICE_ROLE = arn:aws:iam::736913556139:role/cloud-formation-service-role-production
 CODEBUILD_SERVICE_ROLE = arn:aws:iam::736913556139:role/service-role/code-build-service-role-production
 CODEPIPELINE_SERVICE_ROLE = arn:aws:iam::736913556139:role/code-pipeline-service-role-production


### PR DESCRIPTION
This change updates the common infrastructure that is used for build and deploy. It needed to be made for Seedbank to allow multi-region deploys for a CloudFront WAF deployment. Updating all the other projects will give them that capability if it's required, it also keeps things clean as we don't want to be maintaining and supporting parallel infrastructure where some products use one and some use another.

Also taking the opportunity to slightly change the thinking around common infrastructure, all projects will use the production versions by default. stage, test and dev versions are reserved for testing changes in common infrastructure and may not be stable or present in each AWS account