### PR TITLE
Update the build containers

### DIFF
--- a/cicd/static-page/pipeline/deploy_notification_buildspec.yaml
+++ b/cicd/static-page/pipeline/deploy_notification_buildspec.yaml
@@ -9,14 +9,12 @@ env:
   exported-variables:
     - CODEBUILD_BUILD_NUMBER
   secrets-manager:
-    DD_API_KEY: ala-secrets:datadog-api-key
-    SLACK_OAUTH_TOKEN: ala-secrets:slack-oauth-token
+    DD_API_KEY: ala-secrets-production:datadog-api-key
+    SLACK_OAUTH_TOKEN: ala-secrets-production:slack-oauth-token
 
 phases:
 
   install:
-    runtime-versions:
-      python: 3.9
     commands:
       - echo Running on $(lsb_release -d | cut -f2)
       - echo aws-cli version $(aws --version)

--- a/cicd/static-page/pipeline/deploy_notification_buildspec.yaml
+++ b/cicd/static-page/pipeline/deploy_notification_buildspec.yaml
@@ -35,7 +35,7 @@ phases:
       - echo commit msg is $COMMIT_MSG
       - echo commit id is $COMMIT_ID
       - echo Repo is $REPO
-      - export DEPLOY_MSG="Hello! $AUTHOR has released a ${ENVIRONMENT} update to $PRODUCT_NAME $PRODUCT_COMPONENT. Now live at https://${SUB_DOMAIN}.${HOSTED_ZONE}"
+      - export DEPLOY_MSG="$AUTHOR has released a ${ENVIRONMENT} update to $PRODUCT_NAME $PRODUCT_COMPONENT. Now live at https://${SUB_DOMAIN}.${HOSTED_ZONE}"
       - echo $DEPLOY_MSG
     finally:
       - #echo This always runs

--- a/cicd/static-page/pipeline/deploy_notification_buildspec.yaml
+++ b/cicd/static-page/pipeline/deploy_notification_buildspec.yaml
@@ -37,7 +37,7 @@ phases:
       - echo commit msg is $COMMIT_MSG
       - echo commit id is $COMMIT_ID
       - echo Repo is $REPO
-      - export DEPLOY_MSG="$AUTHOR has released a ${ENVIRONMENT} update to $PRODUCT_NAME $PRODUCT_COMPONENT. Now live at https://${SUB_DOMAIN}.${HOSTED_ZONE}"
+      - export DEPLOY_MSG="Hello! $AUTHOR has released a ${ENVIRONMENT} update to $PRODUCT_NAME $PRODUCT_COMPONENT. Now live at https://${SUB_DOMAIN}.${HOSTED_ZONE}"
       - echo $DEPLOY_MSG
     finally:
       - #echo This always runs

--- a/cicd/static-page/pipeline/export_config_buildspec.yaml
+++ b/cicd/static-page/pipeline/export_config_buildspec.yaml
@@ -24,11 +24,10 @@ env:
 phases:
 
   install:
-    runtime-versions:
-      python: 3.9
     commands:
       - echo Running on $(lsb_release -d | cut -f2)
       - echo aws-cli version $(aws --version)
+      - pip install jinja2
       - export CUR_PIPELINE_FINGERPRINT=$(md5sum cicd/static-page/pipeline/pipeline.yaml | awk '{print $1}')
       - # This next bit checks if the running pipeline is out of sync with the pipeline in the
       - # current code revision. If it is it re-launches itself! For a normal branch commit the

--- a/cicd/static-page/pipeline/pipeline.yaml
+++ b/cicd/static-page/pipeline/pipeline.yaml
@@ -67,7 +67,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         EnvironmentVariables:
           - Name: AWS_ARTIFACTS_BUCKET
             Value:
@@ -95,7 +95,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         EnvironmentVariables:
           - Name: "AWS_ARTIFACTS_BUCKET"
             Value:
@@ -121,7 +121,7 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         EnvironmentVariables:
           - Name: "AWS_ARTIFACTS_BUCKET"
             Value:
@@ -147,10 +147,10 @@ Resources:
       Environment:                         
         Type: LINUX_CONTAINER              
         ComputeType: BUILD_GENERAL1_SMALL  
-        Image: aws/codebuild/standard:5.0  
+        Image: aws/codebuild/standard:7.0
         EnvironmentVariables:              
           - Name: CLEAN_BRANCH             
-            Value: !Ref pCleanBranch       
+            Value: !Ref pCleanBranch
       Source:                             
         Type: CODEPIPELINE
         BuildSpec: !Sub cicd/${pProductComponent}/pipeline/deploy_notification_buildspec.yaml


### PR DESCRIPTION
- updated the build containers to latest Ubuntu22.04
- removed hard coded python version, just use what comes with the build container 3.11 in this case
- fixed secret name to use the Bedrock managed secret 